### PR TITLE
Bugfix for where base URL changes 

### DIFF
--- a/lib/sheets/get.js
+++ b/lib/sheets/get.js
@@ -9,7 +9,7 @@ exports.create = function(options) {
   };
 
   var listSheets = function(getOptions, callback) {
-    return utils.get(_.extend(optionsToSend, getOptions), callback);
+    return utils.get(_.extend({}, optionsToSend, getOptions), callback);
   };
 
   var getSheetAsCSV = function(getOptions, callback) {
@@ -25,13 +25,14 @@ exports.create = function(options) {
   };
 
   var getSheetVersion = function(getOptions, callback) {
-    optionsToSend.url = options.apiUrls.sheets + getOptions.sheetId + '/version';
-    return listSheets(_.extend(getOptions, optionsToSend), callback);
+    getOptions.url = options.apiUrls.sheets + getOptions.sheetId + '/version';
+    return listSheets(_.extend({}, optionsToSend, getOptions), callback);
   };
 
   var listOrganizationSheets = function(getOptions, callback) {
-    optionsToSend.url = options.apiUrls.users + 'sheets';
-    return utils.get(_.extend(optionsToSend, getOptions), callback);
+    getOptions = getOptions || {};
+    getOptions.url = options.apiUrls.users + 'sheets';
+    return utils.get(_.extend({}, optionsToSend, getOptions), callback);
   };
 
   return {

--- a/test/client.js
+++ b/test/client.js
@@ -79,7 +79,7 @@ describe('Client Unit Tests', function() {
     });
 
     it('should have delete methods', function() {
-      smartsheet.folders.should.have.property('deleteFolders');
+      smartsheet.folders.should.have.property('deleteFolder');
     });
   });
 
@@ -151,7 +151,7 @@ describe('Client Unit Tests', function() {
   describe('#Sheets', function() {
     it('should have Sheets object',function(){
       smartsheet.should.have.property('sheets');
-      Object.keys(smartsheet.sheets).should.be.length(53);
+      Object.keys(smartsheet.sheets).should.be.length(55);
     });
 
     it('should have Sheets get methods', function() {

--- a/test/sheets.js
+++ b/test/sheets.js
@@ -1,0 +1,51 @@
+var sinon = require('sinon');
+var should = require('should');
+var utils = require('../lib/utils/httpUtils.js');
+
+var smartsheet = null;
+var getSpy = null;
+
+describe('Client Unit Tests', function() {
+  beforeEach(function() {
+    client = require('../');
+    smartsheet = client.createClient({accessToken:'1234'});
+
+    getSpy = sinon.spy(utils, 'get');
+  });
+
+  afterEach(function() {
+    smartsheet = null;
+    utils.get.restore();
+  });
+
+  describe('#Sheets', function() {
+    it('should not change base URL when getSheetVersion is called first', function() {
+      // First call to getSheet
+      smartsheet.sheets.getSheet({ id: 100 });
+      should(getSpy.firstCall.args[0]).have.property('url', '2.0/sheets/');
+
+      // First call to getSheetVersion
+      smartsheet.sheets.getSheetVersion({ sheetId: 100 });
+      should(getSpy.secondCall.args[0]).have.property('url', '2.0/sheets/100/version');
+
+      // Second call to getSheet
+      smartsheet.sheets.getSheet({ id: 100 });
+      should(getSpy.thirdCall.args[0]).have.property('url', '2.0/sheets/');
+    });
+
+    it('should not change base URL when getOrganizationSheets is called first', function () {
+      // First call to getSheet
+      smartsheet.sheets.getSheet({ id: 100 });
+      should(getSpy.firstCall.args[0]).have.property('url', '2.0/sheets/');
+
+      // First call to getSheetVersion
+      smartsheet.sheets.listOrganizationSheets();
+      should(getSpy.secondCall.args[0]).have.property('url', '2.0/users/sheets');
+
+      // Second call to getSheet
+      smartsheet.sheets.getSheet({ id: 100 });
+      should(getSpy.thirdCall.args[0]).have.property('url', '2.0/sheets/');
+
+    });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -157,7 +157,7 @@ describe('Utils Unit Tests', function() {
 
       it('Content-Disposition should equal filename', function() {
         var headers = smartsheet.internal.buildHeaders({fileName: 'test'});
-        headers['Content-Disposition'].should.equal('attachment; filename=test');
+        headers['Content-Disposition'].should.equal('attachment; filename="test"');
       });
 
       it('Content-Length should equal 123', function() {


### PR DESCRIPTION
I found a bug when using the library: if you first make a call to `smartsheet.sheets.getSheetVersion` or `smartsheet.sheets.listOrganizationSheets`, this function changes the base URL in the code, so subsequent sheet requests go to the wrong URL. You will see this wrong behaviour if you run the tests I added (in `tests/sheets.js`) on the current version of the library. This is a bugfix for this problem: in the file `lib/sheets/get.js`, I've just made sure that the `optionsToSend` object is never mutated, so each method call starts with the right base URL. Thanks!
