### PR TITLE
added support for GET, LIST, and DELETE Sights and for sharing Sights

### DIFF
--- a/ExampleUsage.md
+++ b/ExampleUsage.md
@@ -124,6 +124,15 @@ The following code examples show how to call various methods using this SDK.
     - [share](#share-1)
     - [deleteShare](#deleteshare-1)
     - [updateShare](#updateshare-1)
+- [Sight API methods](#sight-api-methods)
+    - [getSight](#getsight)
+    - [listSights](#listsights)
+    - [deleteSight](#deletesight)
+    - [getShare](#getshare-2)
+    - [listShares](#listshares-2)
+    - [share](#share-2)
+    - [deleteShare](#deleteshare-2)
+    - [updateShare](#updateshare-2)
 - [Template API methods](#template-api-methods)
     - [listUserCreatedTemplates](#listusercreatedtemplates)
     - [listPublicTemplates](#listpublictemplates)
@@ -2829,6 +2838,176 @@ The following code examples show how to call various methods using this SDK.
         }
      };
      smartsheet.sheets.updateShare(options, function(error, data) {
+       if (error) {
+         console.log(error);
+       }
+       console.log(data);
+     });
+
+### Sight API methods
+
+#### getSight
+[back to TOC](#table-of-contents)
+#### Example using promises
+
+    smartsheet.sights.getSight({ id: sightId })
+    .then(function(data) {
+      console.log(data);
+    })
+    .catch(function(error) {
+      console.log(error);
+    })
+
+#### Example using callbacks
+
+    smartsheet.sights.getSights({ id: sightId }, function(error, data) {
+      if (error) {
+        console.log(error);
+      }
+      console.log(data);
+    });
+
+#### listSights
+[back to TOC](#table-of-contents)
+#### Example using promises
+
+    smartsheet.sights.listSights()
+    .then(function(data) {
+      console.log(data);
+    })
+    .catch(function(error) {
+      console.log(error);
+    })
+
+#### Example using callbacks
+
+    smartsheet.sights.listSights({}, function(error, data) {
+      if (error) {
+        console.log(error);
+      }
+      console.log(data);
+    });
+
+#### deleteSight
+[back to TOC](#table-of-contents)
+#### Example using promises
+
+    smartsheet.sights.deleteSight({ id: sightId })
+    .then(function(data) {
+      console.log(data);
+    })
+    .catch(function(error) {
+      console.log(error);
+    });
+
+#### Example using callbacks
+
+    smartsheet.sights.deleteSight({ id: sightId }, function(error, data) {
+      if (error) {
+        console.log(error);
+      }
+      console.log(data);
+    })
+
+#### getShare
+[back to TOC](#table-of-contents)
+##### Example using promises
+
+     smartsheet.sights.getShare({ sightId: sightId, shareId: shareId })
+     .then(function(data) {
+       console.log(data);
+     })
+     .catch(function(error) {
+       console.log(error);
+     });
+
+##### Example using callbacks
+
+     smartsheet.sights.getShare({ sightId: sightId, shareId: shareId }, function(error, data) {
+       if (error) {
+         console.log(error);
+       }
+       console.log(data);
+     });
+
+#### listShares
+[back to TOC](#table-of-contents)
+##### Example using promises
+
+     smartsheet.sights.listShares({ sightId: sightId })
+     .then(function(data) {
+       console.log(data);
+     })
+     .catch(function(error) {
+       console.log(error);
+     });
+
+##### Example using callbacks
+
+     smartsheet.sights.listShares({ sightId: sightId }, function(error, data) {
+       if (error) {
+         console.log(error);
+       }
+       console.log(data);
+     });
+
+#### share
+[back to TOC](#table-of-contents)
+##### Example using promises
+
+     smartsheet.sights.share({ body: [{ "email": email, "accessLevel": PERMISSION }], sightId: sightId })
+     .then(function(data) {
+       console.log(data);
+     })
+     .catch(function(error) {
+       console.log(error);
+     });
+
+##### Example using callbacks
+
+     smartsheet.reports.share({ body: [{ "email": email, "accessLevel": PERMISSION }], sightId: sightId }, function(error, data) {
+       if (error) {
+         console.log(error);
+       }
+       console.log(data);
+     });
+
+#### deleteShare
+[back to TOC](#table-of-contents)
+##### Example using promises
+
+     smartsheet.sights.deleteShare({ sightId: sightId, shareId: shareId })
+     .then(function(data) {
+       console.log(data);
+     })
+     .catch(function(error) {
+       console.log(error);
+     });
+
+##### Example using callbacks
+
+     smartsheet.sights.deleteShare({ sightId: sightId, shareId: shareId }, function(error, data) {
+       if (error) {
+         console.log(error);
+       }
+       console.log(data);
+     });
+
+#### updateShare
+[back to TOC](#table-of-contents)
+##### Example using promises
+
+     smartsheet.sights.updateShare({ body: { "accessLevel": PERMISSION }, sightId: sightId, shareId: shareId })
+     .then(function(data) {
+       console.log(data);
+     })
+     .catch(function(error) {
+       console.log(error);
+     });
+
+##### Example using callbacks
+
+     smartsheet.sights.updateShare({ body: { "accessLevel": PERMISSION }, sightId: sightId, shareId: shareId }, function(error, data) {
        if (error) {
          console.log(error);
        }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ exports.createClient = function(options) {
     search     : require('./lib/search/').create(options),
     server     : require('./lib/server/').create(options),
     sheets     : require('./lib/sheets/').create(options),
+    sights     : require('./lib/sights/').create(options),
     templates  : require('./lib/templates/').create(options),
     users      : require('./lib/users/').create(options),
     workspaces : require('./lib/workspaces/').create(options)

--- a/lib/share/share.js
+++ b/lib/share/share.js
@@ -31,7 +31,7 @@ module.exports = function(url) {
       };
 
       var buildUrl = function (urlOptions) {
-        return url + (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId) + '/shares/' + (urlOptions.shareId || '');
+        return url + (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId || urlOptions.sightId) + '/shares/' + (urlOptions.shareId || '');
       };
 
       return {

--- a/lib/sights/index.js
+++ b/lib/sights/index.js
@@ -1,0 +1,34 @@
+var utils = require('../utils/httpUtils.js');
+var _ = require('underscore');
+var constants = require('../utils/constants.js');
+
+exports.create = function(options) {
+  var shares = require('../share/share.js')(options.apiUrls.sights);
+
+  var optionsToSend = {
+    url: options.apiUrls.sights,
+    accessToken : options.accessToken
+  };
+
+  var getSight = function(getOptions, callback) {
+    return utils.get(_.extend(optionsToSend, getOptions), callback);
+  };
+
+  var deleteSight = function(deleteOptions, callback) {
+    optionsToSend.url = options.apiUrls.sights;
+    return utils.delete(_.extend(optionsToSend, deleteOptions), callback);
+  };
+
+  var buildSightObject = function() {
+    var sightObject = {
+      listSights : getSight,
+      getSight   : getSight,
+      deleteSight : deleteSight
+    };
+    
+    sightObject = _.extend(sightObject, shares.create(options));
+    return sightObject;
+  };
+
+  return buildSightObject();
+};

--- a/lib/utils/apis.js
+++ b/lib/utils/apis.js
@@ -7,6 +7,7 @@ module.exports = {
   search           :  '2.0/search/',
   server           :  '2.0/serverinfo/',
   sheets           :  '2.0/sheets/',
+  sights           :  '2.0/sights/',
   templates        :  '2.0/templates/',
   templatesPublic  :  '2.0/templates/public',
   users            :  '2.0/users/',

--- a/test/client.js
+++ b/test/client.js
@@ -225,6 +225,152 @@ describe('Client Unit Tests', function() {
       smartsheet.sheets.should.have.property('deleteSheet');
     });
   });
+  describe('#Sights', function() {
+    it('should have Sights object',function(){
+      smartsheet.should.have.property('sights');
+      Object.keys(smartsheet.sights).should.be.length(8);
+    });
+
+    it('should have Sights get methods', function() {
+      smartsheet.sights.should.have.property('getSight');
+      smartsheet.sights.should.have.property('listSights');
+      smartsheet.sights.should.have.property('getShare');
+      smartsheet.sights.should.have.property('listShares');
+    });
+
+    it('should have Sights delete methods', function() {
+      smartsheet.sights.should.have.property('deleteSight');
+      smartsheet.sights.should.have.property('deleteShare');
+    });
+
+    it('should return correct response from getSight', function() {
+          const sights = require('../lib/sights')
+          const getSightExpectedResponse = {
+          "id": 2591554075418573,
+          "name": "Test",
+          "accessLevel": "OWNER",
+          "columnCount": 6,
+          "widgets": [
+              {
+              "id": 3056651398234562,
+              "type": "RICHTEXT",
+              "contents": {
+                  "htmlContent": "<p>This is a test</p>"
+              },
+              "xPosition": 2,
+              "yPosition": 0,
+              "width": 2,
+              "height": 4,
+              "showTitleIcon": false,
+              "titleFormat": ",,1,,,,,,,3,,,,,,",
+              "version": 1
+              },
+              {
+              "id": 48092647672583496,
+              "type": "SHORTCUTLIST",
+              "contents": {
+                  "shortcutData": [
+                  {
+                      "label": "Sight Data",
+                      "labelFormat": ",2,,,,,1,,1,,,,,,,",
+                      "hyperlink": {
+                      "url": "https://app.smartsheet.com/b/home?lx=m1O5qo7tpM1h23KFxYavIw",
+                      "sheetId": 692061146243972
+                      },
+                      "attachmentType": "SMARTSHEET",
+                      "order": 0
+                  }
+                  ]
+              },
+              "xPosition": 1,
+              "yPosition": 0,
+              "width": 1,
+              "height": 1,
+              "showTitleIcon": false,
+              "titleFormat": ",,1,,,,,,,3,,,,,,",
+              "version": 1
+              }
+          ]
+          };
+          
+          const httpUtilsGetMock = {
+            get: function(optionsToSend, callback) {
+              callback(getSightExpectedResponse);
+            }
+          };
+
+          const theSight = sights.create({
+          apiUrls: {sights: '...'},
+          httpUtils: httpUtilsGetMock
+          });
+
+          theSight.getSight({id:2591554075418573}, (data) => {
+          should.deepEqual(data, getSightExpectedResponse);
+          });
+
+        })
+    it('should return the correct response from listSights', function() {
+      const sights = require('../lib/sights')
+      const listSightsExpectedResponse = {
+              "pageNumber": 1,
+              "pageSize": 100,
+              "totalPages": 1,
+              "totalCount": 2,
+              "data": [
+                  {
+                      "id": 2331373580117892,
+                      "name": "Sales Sight",
+                      "accessLevel": "OWNER",
+                      "permalink": "https://app.smartsheet.com/b/home?lx=xUefSOIYmn07iJJesvSHCQ",
+                      "createdAt": "2016-01-28T00:24:41Z",
+                      "modifiedAt": "2016-01-28T20:32:33Z"
+                  },
+                  {
+                      "id": 7397923160909700,
+                      "name": "Sight #2",
+                      "accessLevel": "OWNER",
+                      "permalink": "https://app.smartsheet.com/b/home?lx=xUefSOIYmn07iJJrthEFTG",
+                      "createdAt": "2016-01-28T01:17:51Z",
+                      "modifiedAt": "2016-01-28T20:32:27Z"
+                  }
+              ]
+          }
+      const httpUtilsListMock = {
+        delete: function(optionsToSend, callback) {
+          callback(listSightsExpectedResponse);
+        }
+      }
+      const theSight = sights.create({
+          apiUrls: {sights: '...'},
+          httpUtils: httpUtilsListMock
+          });
+
+          theSight.listSights({}, (data) => {
+          should.deepEqual(data, listSightsExpectedResponse);
+          });
+    });
+
+    it('should return the correct response from deleteSight', function() {
+      const sights = require('../lib/sights')
+      const deleteSightExpectedResponse = {
+                    "resultCode": 0,
+                    "message": "SUCCESS"
+            }
+      const httpUtilsDeleteMock = {
+        delete: function(optionsToSend, callback) {
+          callback(deleteSightExpectedResponse);
+        }
+      }
+      const theSight = sights.create({
+          apiUrls: {sights: '...'},
+          httpUtils: httpUtilsDeleteMock
+          });
+
+          theSight.deleteSight({id:2591554075418573}, (data) => {
+          should.deepEqual(data, deleteSightExpectedResponse);
+          });
+    });
+  })
 
   describe('#templates', function () {
     it('should have templates object', function () {


### PR DESCRIPTION
I followed the conventions in the SDK as it is built for requests against sheets and reports. As there aren't any specific tests to run I tested each request manually and got expected results from each. 
I only added support specifically to GET a sight by id, List All Sights, and to DELETE sight.
I manually tested each of sharing end points and they worked as expected for sights.