### PR TITLE
Change process.env.HOST to SMARTSHEET_API_HOST

### DIFF
--- a/lib/utils/httpUtils.js
+++ b/lib/utils/httpUtils.js
@@ -36,7 +36,7 @@ exports.handleResponse = function(response, body) {
 };
 
 var buildUrl = function(options) {
-  var baseUrl = process.env.HOST || 'https://api.smartsheet.com/';
+  var baseUrl = process.env.SMARTSHEET_API_HOST || 'https://api.smartsheet.com/';
   if (options.id) {
     return baseUrl + options.url + options.id;
   } else {


### PR DESCRIPTION
The smartsheet SDK uses `process.env.HOST` to set the base URL for the smartsheet API. The name for this setting is too generic and any consumer of this SDK could accidentally set this variable in their app, inadvertently breaking the smartsheet SDK.