### PR TITLE
Add support for the 'Change Agent' header.

### DIFF
--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -38,8 +38,11 @@ exports.create = function(requestorConfig) {
       headers['Content-Disposition'] = `attachment; filename="${options.fileName}"`;
       headers['Content-Length'] = options.fileSize;
     }
-    if(options.apiScenario){
-      headers['Api-Scenario'] = (options.apiScenario);
+    if(options.apiScenario) {
+      headers['Api-Scenario'] = options.apiScenario;
+    }
+    if(options.changeAgent) {
+      headers['Smartsheet-Change-Agent'] = options.changeAgent;
     }
     return headers;
   };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha \"test/**/*_test.js\"",
     "test-functional": "mocha \"test/functional/**/*_test.js\"",
     "test-mock-api": "mocha \"test/mock-api/**/*_test.js\"",
-    "coverage": "istanbul cover _mocha -- -u exports -R spec \"test/functional/**/*.js\"",
+    "coverage": "istanbul cover _mocha -- -u exports -R spec \"test/**/*_test.js\"",
     "report-coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {

--- a/test/mock-api/header_test.js
+++ b/test/mock-api/header_test.js
@@ -1,0 +1,35 @@
+var sinon = require("sinon");
+var should = require("should");
+var assert = require("assert");
+var helpers = require("./helpers");
+
+describe("Mock API SDK Tests", function() {
+  var client = helpers.setupClient();
+
+  beforeEach(helpers.setupMockApiTest);
+
+  describe("#Header", function() {
+    var scenarios = [
+        {
+          "name": "Change Agent Header - Can Be Passed",
+          "method": client.sheets.createSheet,
+          "shouldError": false,
+          "options": {
+            "body": {
+              "name": "My new sheet",
+              "columns": [
+                {
+                  "title": "Col1",
+                  "primary": true,
+                  "type": "TEXT_NUMBER"
+                }
+              ]
+            },
+            "changeAgent": "MyChangeAgent"
+          }
+        }
+      ];
+
+    helpers.defineMockApiTests(scenarios);
+  });
+});


### PR DESCRIPTION
Allows you to add a `changeAgent` option to any call in order to set the `Smartsheet-Change-Agent` header in the request.