### PR TITLE
Smartsheetgov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+Updated documentation regarding the usage of baseUrl to clarify how clients can access smartsheetgov
 
 ## 1.4.1 - December 7, 2018
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ var smartsheet = require('smartsheet').createClient({
 });
 ```
 
+To create a SmartsheetGov client, the baseURL will need to be `constants.baseURIs.govBaseURI`.
+
+```javascript
+var smartsheet = require('smartsheet').createClient({
+  baseUrl: constants.baseURIs.govBaseURI
+});
+```
+
 ## Testing
 
 The source code comes with several scripts for running tests:

--- a/README.md
+++ b/README.md
@@ -151,13 +151,7 @@ var smartsheet = require('smartsheet').createClient({
 });
 ```
 
-To create a SmartsheetGov client, the baseURL will need to be `constants.baseURIs.govBaseURI`.
-
-```javascript
-var smartsheet = require('smartsheet').createClient({
-  baseUrl: constants.baseURIs.govBaseURI
-});
-```
+To create a SmartsheetGov client, the `baseUrl` will need to be `https://api.smartsheetgov.com/2.0`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "1.4.2",
+  "version": "1.4.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "1.5.0",
+  "version": "1.4.2",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In order to give clients more information on how to access smartsheetgov, I added some clearer documentation regarding the usage of the `baseUrl` parameter when creating a client. 
